### PR TITLE
Update ._main_nonlin001.html

### DIFF
--- a/doc/pub/nonlin/sphinx/._main_nonlin001.html
+++ b/doc/pub/nonlin/sphinx/._main_nonlin001.html
@@ -131,8 +131,8 @@ constants <span class="math">\(a\)</span> and <span class="math">\(b\)</span>,</
 \[T(au_1 + bu_2) = aT(u_1) + bT(u_2){\thinspace .}\]</div>
 <p>For example, the term <span class="math">\(T(u) = (\sin^2 t)u'(t)\)</span> is linear because</p>
 <div class="math">
-\[\begin{split}T(au_1 + bu_2) &amp;= (\sin^2 t)(au_1(t) + b u_2(t))\\
-&amp; = a(\sin^2 t)u_1(t) + b(\sin^2 t)u_2(t)\\
+\[\begin{split}T(au_1 + bu_2) &amp;= (\sin^2 t)(au_1(t) + b u_2(t))'\\
+&amp; = a(\sin^2 t)u_1'(t) + b(\sin^2 t)u_2'(t)\\
 &amp; =aT(u_1) + bT(u_2){\thinspace .}\end{split}\]</div>
 <p>However, <span class="math">\(T(u)=\sin u\)</span> is nonlinear because</p>
 <div class="last math">


### PR DESCRIPTION
The mathematical proof of linearity was was missing the derivative prime symbols that are needed.